### PR TITLE
[fix] 로그인 후 불필요한 /refresh 요청 방지

### DIFF
--- a/src/app/providers/auth-initializer-provider.tsx
+++ b/src/app/providers/auth-initializer-provider.tsx
@@ -12,6 +12,12 @@ export const AuthInitializerProvider = ({ children }: AuthInitializerProps) => {
 
 	useEffect(() => {
 		const initializeAuth = async () => {
+			// 첫 로그인이라 OauthCallback에서 이미 accessToken 인증이 완료된 경우 accessToken refresh 스킵
+			const { isAuthenticated } = useAuthStore.getState();
+			if (isAuthenticated) {
+				return;
+			}
+
 			try {
 				// AuthInitializer는 앱 시작 시 한 번 호출되며, UI 상태가 불필요하므로 굳이 useMutation 사용 불필요
 				const response = await postRefreshAccessToken();


### PR DESCRIPTION
## 📌 Summary
_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #114 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks
_해당 PR에 수행한 작업을 작성해주세요._

### 해결 실패로 코드 수정 중...

**[문제상황]**
기존회원 로그인 → 로그인 과정에 따라 네트워크 탭에 `/tokens`, `/refresh`가 찍히는 것까지는 정상이에요. 네트워크탭 확인해보면 `/tokens`의 응답헤더에도 `set-cookie`에 `refreshToken`이 정상적으로 잘 들어가있음을 확인 가능해요.

근데 /refresh 요청(refreshToken으로 accessToken 요청하는 API), 즉 `<AuthInitializerProvider>`에 진입했을 때 실행되는 이 API 요청의 요청 헤더를 확인해보면 이미 이전 `/tokens` 요청의 응답에서 refreshToken이 정상적으로 도착했음에도, 그리고 요청에 refreshToken이 필요함에도 요청헤더에 포함되지 않은 상태로 요청됨을 확인할 수 있어요.


**[문제원인]**
문제 원인은 브라우저의 쿠키 저장 타이밍 시점인 듯해요.

`/tokens` 응답 도착 (Set-Cookie: refreshToken)
→ navigate(HOME)  `← 즉시 실행`
→ AuthInitializer 실행
→ `/refresh` 요청 ← `쿠키가 아직 저장 안됨!`

Set-Cookie로 받은 쿠키가 브라우저에 완전히 저장되기 전에 다음 요청이 나가버리는 문제일 것 같아요.


**[해결시도]**
OAuthCallback을 통해 들어온 경우 AuthInitializer에서 refresh 요청이 불필요해요(`/refresh` 요청은 accessToken을 갱신하는 요청인데, 첫 로그인인 경우 카카오 로그인 → oneTimeToken 반환 및 `<OAuthCallback>`로 리다이렉트 → 이 페이지에서 `/tokens` 요청으로 accessToken을 이미 발급 받았으므로 AuthInitializer에서 다시 refresh 요청을 할 필요가 없음)

⇒ AuthInitializer에서 전역상태 `isAuthenticated`에 접근해 이게 true면(accessToken이 잘 발급된 인증된 상태라면) refresh 요청을 보내지 않도록 설정했어요.

## 🔍 To Reviewer
_리뷰어에게 요청하는 내용을 작성해주세요._

-

## 📸 Screenshot
_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 인증 시작 프로세스 최적화로 앱 로딩 성능 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->