### PR TITLE
[refactor] 회원가입 생년월일 범위 및 가이드 문구 수정

### DIFF
--- a/src/pages/signup/ui/signup.tsx
+++ b/src/pages/signup/ui/signup.tsx
@@ -89,6 +89,7 @@ export const Signup = () => {
 					<div className="flex flex-col gap-[1.2rem]">
 						<InputMedium
 							label="이름"
+							placeholder="성명 입력"
 							required
 							{...register("name")}
 							errorMessage={errors.name?.message}

--- a/src/shared/libs/validation/schemas/base-schemas.ts
+++ b/src/shared/libs/validation/schemas/base-schemas.ts
@@ -24,7 +24,7 @@ export const birthDateSchema = z
 		(data) => {
 			if (!data.year) return true;
 			const year = Number(data.year);
-			return year >= 1960 && year <= 2007;
+			return year >= 1956 && year <= 2007;
 		},
 		{ message: ERROR_MESSAGES.birthDate.invalidYear },
 	)

--- a/src/shared/libs/validation/schemas/error-messages.ts
+++ b/src/shared/libs/validation/schemas/error-messages.ts
@@ -5,7 +5,7 @@ export const ERROR_MESSAGES = {
 		invalidChar: "한글만 입력 가능해요.",
 	},
 	birthDate: {
-		invalidYear: "1960년~2007년 사이의 연도를 입력해 주세요.",
+		invalidYear: "1956년~2007년 사이의 연도를 입력해 주세요.",
 		invalidDate: "올바른 날짜를 입력해 주세요.",
 	},
 	checkupDate: {


### PR DESCRIPTION
## 📌 Summary
- close #155 

## 📄 Tasks
- 디자인 변경사항 반영
  - 상단 가이드 문구 수정
  - 버튼 하단 여백 조정
- 회원가입 생년월일 범위 및 에러 메시지 수정

## 🔍 To Reviewer
- 정말 간단한 UI 수정이랑 생년월일 범위 1956~2007로 수정하였습니다!

## 📸 Screenshot
https://github.com/user-attachments/assets/367bb329-8dce-4ef8-95a4-4ccc8af19fbf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI 업데이트**
  - 가입 페이지 여백 조정
  - 안내 문구 텍스트 변경
  - 성명 입력 필드에 입력 안내 추가

* **유효성 검증 개선**
  - 생년월일 입력 가능 범위 확대 (1956년 이상 허용)
  - 관련 검증 오류 메시지 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->