### PR TITLE
[feat] GA 연동

### DIFF
--- a/src/app/providers/router-provider.tsx
+++ b/src/app/providers/router-provider.tsx
@@ -1,6 +1,18 @@
+import { trackPageView } from "@shared/libs/analytics";
+import { useEffect } from "react";
 import { RouterProvider as ReactRouterProvider } from "react-router";
 import { router } from "../routes/router";
 
 export const RouterProvider = () => {
+	useEffect(() => {
+		trackPageView(window.location.pathname);
+
+		const unsubscribe = router.subscribe((state) => {
+			trackPageView(state.location.pathname);
+		});
+
+		return unsubscribe;
+	}, []);
+
 	return <ReactRouterProvider router={router} />;
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,9 @@
+import { initGA } from "@shared/libs/analytics";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-
 import { App } from "@/app/App";
+
+initGA();
 
 const rootElement = document.getElementById("root");
 

--- a/src/pages/checkup-result-edit/apis/mutations/use-health-report-update-mutation.ts
+++ b/src/pages/checkup-result-edit/apis/mutations/use-health-report-update-mutation.ts
@@ -1,3 +1,4 @@
+import { trackCheckupEdit } from "@shared/libs/analytics";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import { ROUTE_PATH } from "@/app/routes/paths";
@@ -24,6 +25,7 @@ export const useHealthReportUpdateMutation = () => {
 			putHealthReport(healthReportId, data),
 		throwOnError: false,
 		onSuccess: async (_data, variables) => {
+			trackCheckupEdit();
 			await Promise.all([
 				queryClient.invalidateQueries({
 					queryKey: queryKeys.member.info(),

--- a/src/pages/checkup-result/apis/mutations/use-health-report-mutation.ts
+++ b/src/pages/checkup-result/apis/mutations/use-health-report-mutation.ts
@@ -1,3 +1,4 @@
+import { trackCheckupSubmit } from "@shared/libs/analytics";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { useNavigate } from "react-router";
@@ -19,6 +20,7 @@ export const useHealthReportMutation = () => {
 		mutationFn: (data: WriteHealthReportRequest) => postHealthReport(data),
 		throwOnError: false,
 		onSuccess: () => {
+			trackCheckupSubmit();
 			void queryClient.invalidateQueries({
 				queryKey: queryKeys.member.info(),
 			});

--- a/src/pages/checkup-result/ui/ocr-section.tsx
+++ b/src/pages/checkup-result/ui/ocr-section.tsx
@@ -1,3 +1,4 @@
+import { trackOcrUploadComplete } from "@shared/libs/analytics";
 import { useRef, useState } from "react";
 import { useLocation } from "react-router";
 import { ROUTE_PATH } from "@/app/routes/paths";
@@ -68,6 +69,7 @@ export const OcrSection = ({ onOcrComplete }: OcrSectionProps) => {
 				]),
 			);
 
+			trackOcrUploadComplete();
 			onOcrComplete?.(stringifiedData);
 		} catch (_err) {
 			notifyError("OCR 변환에 실패했어요. 잠시 후 다시 시도해 주세요.");

--- a/src/pages/health-analysis/health-analysis.tsx
+++ b/src/pages/health-analysis/health-analysis.tsx
@@ -1,3 +1,4 @@
+import { trackHealthAnalysisView } from "@shared/libs/analytics";
 import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import { ROUTE_PATH } from "@/app/routes/paths";
@@ -425,6 +426,10 @@ const DEFAULT_SEX: Sex = "FEMALE";
 const HealthAnalysisPage = () => {
 	const { data: userInfo, isPending } = useMyInfo();
 	const userSex = isPending ? DEFAULT_SEX : (userInfo?.gender ?? DEFAULT_SEX);
+
+	useEffect(() => {
+		trackHealthAnalysisView();
+	}, []);
 
 	return <HealthAnalysisContent userSex={userSex} />;
 };

--- a/src/pages/health-report-detail/ui/health-report-detail.tsx
+++ b/src/pages/health-report-detail/ui/health-report-detail.tsx
@@ -1,3 +1,4 @@
+import { trackHealthReportView } from "@shared/libs/analytics";
 import { useEffect } from "react";
 import { useParams, useSearchParams } from "react-router";
 import { useMyInfo } from "@/shared/apis/member/use-my-info";
@@ -11,12 +12,16 @@ const DOUBLE_NOTICE_TYPES: HealthReportType[] = ["basic", "liver", "anemia"];
 const DEFAULT_SEX: Sex = "FEMALE";
 
 export const HealthReportDetailPage = () => {
+	const { type } = useParams<{ type: HealthReportType }>();
+
 	// 페이지 진입 시 스크롤을 맨 위로 이동 (중간부터 보이는 현상 방지)
 	useEffect(() => {
 		window.scrollTo({ top: 0, left: 0, behavior: "auto" });
 	}, []);
 
-	const { type } = useParams<{ type: HealthReportType }>();
+	useEffect(() => {
+		if (type) trackHealthReportView(type);
+	}, [type]);
 	const [searchParams] = useSearchParams();
 	const healthCheckDate = searchParams.get("healthCheckDate") ?? "";
 	const { data: userInfo, isPending } = useMyInfo();

--- a/src/pages/hospital-search/ui/hospital-search.tsx
+++ b/src/pages/hospital-search/ui/hospital-search.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from "react";
+import { trackHospitalSearchView } from "@shared/libs/analytics";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { useGetSidoCodeQuery } from "@/pages/hospital-search/apis/queries/use-get-sido-code-query";
 import { useGetSigunguCodeQuery } from "@/pages/hospital-search/apis/queries/use-get-sigungu-code-query";
@@ -46,6 +47,10 @@ const getScreeningTypeCode = (label: ScreeningTypeChip) => {
 
 export const HospitalSearchPage = () => {
 	const navigate = useNavigate();
+
+	useEffect(() => {
+		trackHospitalSearchView();
+	}, []);
 
 	const [selectedRegion, setSelectedRegion] = useState<Region>(INITIAL_REGION);
 	const [tempRegion, setTempRegion] = useState<Region>(INITIAL_REGION);

--- a/src/pages/login/ui/login.tsx
+++ b/src/pages/login/ui/login.tsx
@@ -1,3 +1,4 @@
+import { trackKakaoLoginClick } from "@shared/libs/analytics";
 import Lottie from "react-lottie-player";
 import LoginBackGround from "@/shared/assets/img/login-bg.png";
 import LandingGraphic from "@/shared/assets/lottie/landing-graphic.json";
@@ -42,7 +43,12 @@ export const LoginPage = () => {
 				</section>
 
 				<div className="pb-[4rem]">
-					<LoginButton onClick={requestKakaoAuthorize} />
+					<LoginButton
+						onClick={() => {
+							trackKakaoLoginClick();
+							requestKakaoAuthorize();
+						}}
+					/>
 				</div>
 			</div>
 		</div>

--- a/src/pages/my-page/apis/mutations/use-logout.ts
+++ b/src/pages/my-page/apis/mutations/use-logout.ts
@@ -1,3 +1,4 @@
+import { trackLogout } from "@shared/libs/analytics";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { API_ENDPOINTS } from "@/shared/apis/api-endpoints";
 import { HTTP_METHOD, request } from "@/shared/apis/request";
@@ -8,6 +9,7 @@ export const useLogout = () => {
 	return useMutation({
 		mutationFn: postLogout,
 		onSuccess: () => {
+			trackLogout();
 			// 캐시된 모든 쿼리 데이터 삭제
 			queryClient.clear();
 		},

--- a/src/pages/my-page/apis/mutations/use-withdrawal.ts
+++ b/src/pages/my-page/apis/mutations/use-withdrawal.ts
@@ -1,3 +1,4 @@
+import { trackWithdrawal } from "@shared/libs/analytics";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 import { ROUTE_PATH } from "@/app/routes/paths";
@@ -14,6 +15,7 @@ export const useWithdrawal = () => {
 	return useMutation({
 		mutationFn: postWithdrawal,
 		onSuccess: async () => {
+			trackWithdrawal();
 			await queryClient.cancelQueries();
 			logoutStore();
 			queryClient.clear();

--- a/src/pages/signup/ui/tos.tsx
+++ b/src/pages/signup/ui/tos.tsx
@@ -1,5 +1,6 @@
 // tos(terms-of-services), 약관동의 페이지
 
+import { trackSignupComplete } from "@shared/libs/analytics";
 import { useEffect, useState } from "react";
 import Markdown from "react-markdown";
 import { useLocation, useNavigate } from "react-router";
@@ -253,6 +254,7 @@ const ToSPage = () => {
 		if (!signupData || isPending) return;
 		mutate(signupData, {
 			onSuccess: () => {
+				trackSignupComplete();
 				openSignupCompleteModal();
 			},
 			onError: () => {

--- a/src/shared/libs/analytics/events.ts
+++ b/src/shared/libs/analytics/events.ts
@@ -1,0 +1,54 @@
+import { trackEvent } from "./gtag";
+
+const GA_EVENTS = {
+	KAKAO_LOGIN_CLICK: "kakao_login_click",
+	SIGNUP_COMPLETE: "signup_complete",
+	CHECKUP_SUBMIT: "checkup_submit",
+	CHECKUP_EDIT: "checkup_edit",
+	OCR_UPLOAD_COMPLETE: "ocr_upload_complete",
+	HEALTH_ANALYSIS_VIEW: "health_analysis_view",
+	HEALTH_REPORT_VIEW: "health_report_view",
+	HOSPITAL_SEARCH_VIEW: "hospital_search_view",
+	LOGOUT: "logout",
+	WITHDRAWAL: "withdrawal",
+} as const;
+
+export const trackKakaoLoginClick = () => {
+	trackEvent(GA_EVENTS.KAKAO_LOGIN_CLICK);
+};
+
+export const trackSignupComplete = () => {
+	trackEvent(GA_EVENTS.SIGNUP_COMPLETE);
+};
+
+export const trackCheckupSubmit = () => {
+	trackEvent(GA_EVENTS.CHECKUP_SUBMIT);
+};
+
+export const trackCheckupEdit = () => {
+	trackEvent(GA_EVENTS.CHECKUP_EDIT);
+};
+
+export const trackOcrUploadComplete = () => {
+	trackEvent(GA_EVENTS.OCR_UPLOAD_COMPLETE);
+};
+
+export const trackHealthAnalysisView = () => {
+	trackEvent(GA_EVENTS.HEALTH_ANALYSIS_VIEW);
+};
+
+export const trackHealthReportView = (type: string) => {
+	trackEvent(GA_EVENTS.HEALTH_REPORT_VIEW, { report_type: type });
+};
+
+export const trackHospitalSearchView = () => {
+	trackEvent(GA_EVENTS.HOSPITAL_SEARCH_VIEW);
+};
+
+export const trackLogout = () => {
+	trackEvent(GA_EVENTS.LOGOUT);
+};
+
+export const trackWithdrawal = () => {
+	trackEvent(GA_EVENTS.WITHDRAWAL);
+};

--- a/src/shared/libs/analytics/gtag.ts
+++ b/src/shared/libs/analytics/gtag.ts
@@ -1,0 +1,39 @@
+import "./types";
+
+const GA_MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID as
+	| string
+	| undefined;
+
+export const initGA = () => {
+	if (!GA_MEASUREMENT_ID) return;
+
+	const script = document.createElement("script");
+	script.async = true;
+	script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
+	document.head.appendChild(script);
+
+	window.dataLayer = window.dataLayer || [];
+	window.gtag = function () {
+		// biome-ignore lint/complexity/noArguments: GA4 requires native Arguments object for internal type checking
+		window.dataLayer.push(arguments);
+	};
+	window.gtag("js", new Date());
+	window.gtag("config", GA_MEASUREMENT_ID, {
+		send_page_view: false,
+	});
+};
+
+export const trackPageView = (path: string) => {
+	if (!GA_MEASUREMENT_ID) return;
+	window.gtag("config", GA_MEASUREMENT_ID, {
+		page_path: path,
+	});
+};
+
+export const trackEvent = (
+	eventName: string,
+	params?: Record<string, string | number | boolean>,
+) => {
+	if (!GA_MEASUREMENT_ID) return;
+	window.gtag("event", eventName, params);
+};

--- a/src/shared/libs/analytics/index.ts
+++ b/src/shared/libs/analytics/index.ts
@@ -1,0 +1,13 @@
+export {
+	trackCheckupEdit,
+	trackCheckupSubmit,
+	trackHealthAnalysisView,
+	trackHealthReportView,
+	trackHospitalSearchView,
+	trackKakaoLoginClick,
+	trackLogout,
+	trackOcrUploadComplete,
+	trackSignupComplete,
+	trackWithdrawal,
+} from "./events";
+export { initGA, trackEvent, trackPageView } from "./gtag";

--- a/src/shared/libs/analytics/types.ts
+++ b/src/shared/libs/analytics/types.ts
@@ -1,0 +1,8 @@
+declare global {
+	interface Window {
+		dataLayer: unknown[];
+		gtag: (...args: unknown[]) => void;
+	}
+}
+
+export {};


### PR DESCRIPTION
## 📌 Summary
_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

- close #186 

> 관련 있는 Issue를 태그해주세요. (e.g. > - #1)

## 📄 Tasks
_해당 PR에 수행한 작업을 작성해주세요._

- GA4 기본 세팅 및 페이지뷰 자동 추적 구현
- 핵심 사용자 이벤트 10개 추적 코드 추가
  - 카카오 로그인, 회원가입 완료, 검진결과 제출/수정, OCR 완료, 검진 분석 진입, 상세 리포트 조회, 병원 검색, 로그아웃, 회원탈퇴
- main.tsx에서 GA 초기화, router-provider.tsx에서 SPA 페이지뷰 자동 추적



## 🔍 To Reviewer
_리뷰어에게 요청하는 내용을 작성해주세요._

- .env에 GA Measurement ID가 없으면 GA 코드가 자동 비활성화되므로 개발환경에 영향 없음

## 📸 Screenshot
_작업한 내용에 대한 스크린샷을 첨부해주세요._

-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 분석 인프라를 통합하여 사용자 상호작용 및 페이지 방문 추적 기능을 추가했습니다.
  * 로그인, 가입, 체크업, 건강 리포트, 병원 검색 등 주요 사용자 활동에 대한 추적을 활성화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->